### PR TITLE
Fix L10N_HELPER_HOME resolution

### DIFF
--- a/bin/alh.sh
+++ b/bin/alh.sh
@@ -2,7 +2,6 @@
 #
 # Start-up script
 
-L10N_HELPER_HOME=`dirname "$0"`
-L10N_HELPER_HOME=`dirname "$L10N_HELPER_HOME"`
+L10N_HELPER_HOME="$(dirname "$(readlink -f "$0")")/.."
 
 java -jar $L10N_HELPER_HOME/lib/l10n-helper.jar $1


### PR DESCRIPTION
Use readlink -f to determine path to alh.sh to make it work if it's
called via $PATH resolution.
